### PR TITLE
Upload image prediction table added

### DIFF
--- a/webapp/main.py
+++ b/webapp/main.py
@@ -130,6 +130,8 @@ ALLOWED_EXTENSIONS = set(['pdf', 'png', 'jpg', 'jpeg'])
 
 @app.route("/upload", methods=['POST'])
 def upload():
+
+    upload = True
     target = os.path.join(APP_ROOT, 'images/')
     print(target)
 
@@ -167,8 +169,8 @@ def upload():
     print(sorted_dict)
 
     os.remove(dst)
-    r = json.dumps(sorted_dict)
-    return(str(r))
+
+    return render_template('index.html', upload=upload, sorted_dict=sorted_dict)
 
 if __name__ == "__main__":
 

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -52,6 +52,21 @@
       </div>
 
       <div class="jumbotron">
+        {% if upload %}
+            <table class="table table-dark table-hover">
+                <thead>
+                  <h3>Prediction Results</h3>
+                </thead>  
+                <tbody>
+                    {% for elem in sorted_dict %}
+                    <tr> 
+                        <td>{{ elem[0] }}</td>
+                        <td>{{ elem[1] }}</td> 
+                    </tr>
+                    {% endfor%}
+                </tbody>
+            </table>
+        {% endif%}
       	<p id="result"></p>
       </div>
 


### PR DESCRIPTION
Fixes # <!-- Add the issue number that is fixed by this PR (In the form Fixes #45) -->

#### Checklist:
- [x] 4 space indentation.
- [x] Coding conventions are followed.
- [ ] Docstring Added.


#### Changes proposed in this pull request:

- Whenever we upload an image and click on `predict` button, previously it prints array of tuples which shows that which category has greater probability.
- Now it will be shown in table format whenever you upload an image and click on `predict`.

#### Files Added:
- None
#### Files Affected:
- `index.html`
- `main.py`